### PR TITLE
seqence length and path fix.

### DIFF
--- a/multi_modal_binding/data/data_process.py
+++ b/multi_modal_binding/data/data_process.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import numpy as np
 from Bio import SeqIO
 from sklearn.model_selection import KFold
@@ -125,7 +126,7 @@ def prep_test_dataset(conf, ligand=None):
     with open(conf.inference.fasta_path) as handle:
         recs = list(SeqIO.parse(handle, "fasta"))
 
-    ID_list = [rec.id for rec in recs]
+    ID_list = [rec.id.split("|")[1] for rec in recs]
 
     protein_features = feature_extraction(
         ID_list,
@@ -148,17 +149,18 @@ def multimodal_embedding(
     inference=False,
 ):
     protein_embeddings = {}
+    current_dir=os.path.dirname(__file__)
     max_repr_esm = np.load(
-        "multi_modal_binding/data/normalization_constants/esm_repr_max.npy"
+        os.path.join(current_dir,"normalization_constants/esm_repr_max.npy")
     )
     min_repr_esm = np.load(
-        "multi_modal_binding/data/normalization_constants/esm_repr_min.npy"
+        os.path.join(current_dir,"normalization_constants/esm_repr_min.npy")
     )
     max_repr_esm_if = np.load(
-        "multi_modal_binding/data/normalization_constants/esm_if_repr_max.npy"
+        os.path.join(current_dir,"normalization_constants/esm_if_repr_max.npy")
     )
     min_repr_esm_if = np.load(
-        "multi_modal_binding/data/normalization_constants/esm_if_repr_min.npy"
+        os.path.join(current_dir,"normalization_constants/esm_if_repr_min.npy")
     )
     if inference:
         feature_path_1 = precomputed_feature_path + "/esm"

--- a/multi_modal_binding/get_esm_embedding.py
+++ b/multi_modal_binding/get_esm_embedding.py
@@ -31,10 +31,10 @@ def esm_embedding(ID_list, seq_list, output_path, batch_size, device):
             embedding = (
                 result["representations"][len(model.layers)].detach().cpu().numpy()
             )
-            mask = result["mask"].detach().cpu().numpy()
+            batch_lens=(batch_tokens != alphabet.padding_idx).sum(1)
 
             for seq_num in range(len(embedding)):
-                seq_len = mask[seq_num].sum()
+                seq_len = batch_lens[seq_num]
                 # get rid of cls and eos token
                 seq_emd = embedding[seq_num][1 : (seq_len - 1)]
                 np.save(os.path.join(output_path, batch_labels[seq_num]), seq_emd)


### PR DESCRIPTION
In `get_esm_embedding.py`, result['mask'] raises KeyError.In my test,result only has `logits,representations` keys.I use esm's official example to calculate sequence length and it works.

In `data_process.py`,max_repr_esm = np.load("multi_modal_binding/data/normalization_constants/esm_repr_min.npy")` can't locate the file.I change the path to abspath and it works.

```py
    current_dir=os.path.dirname(__file__)
    max_repr_esm_if = np.load(
        os.path.join(current_dir,"normalization_constants/esm_if_repr_max.npy")
    )
```